### PR TITLE
Pass `str` instead of `pathlib.Path` to Jinja loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Jinja's `FileSystemLoader` gets `str` instead of `pathlib.Path` to fix types incompatibility for `Jinja < 2.11.0`.
+
 ## [0.18.0] - 2022-01-14
 
 ### Added

--- a/dbt_airflow_factory/config_utils.py
+++ b/dbt_airflow_factory/config_utils.py
@@ -106,7 +106,7 @@ def _jinja_replace_airflow_vars(file_path: Union[str, os.PathLike[str]]) -> str:
             return Variable.get(item)
 
     file_path = pathlib.Path(file_path)
-    jinja_loader = FileSystemLoader(file_path.parent)
+    jinja_loader = FileSystemLoader(str(file_path.parent))
     jinja_env = NativeEnvironment(loader=jinja_loader)
 
     return jinja_env.get_template(file_path.name).render(


### PR DESCRIPTION
`FileSystemLoader` in Jinja versions prior to 2.11.0 expected path to be of type `str`. Any other type was treated as an instance of `Iterable`, hence throwing error in the presence of `pathlib.Path` (cf. [2.10.3](https://github.com/pallets/jinja/blob/2.10.3/jinja2/loaders.py#L161) vs [2.11.0](https://github.com/pallets/jinja/blob/2.11.0/src/jinja2/loaders.py#L166)).

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates