### PR TITLE
Use `get_start_task` and `get_end_task` in `AirflowDagFactory.create_tasks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Use `get_start_task()` and `get_end_task()` in `AirflowDagFactory.create_tasks(config)` to prevent ephemeral ending tasks from throwing.
+
 ## [0.18.0] - 2022-01-14
 
 ### Added

--- a/dbt_airflow_factory/airflow_dag_factory.py
+++ b/dbt_airflow_factory/airflow_dag_factory.py
@@ -85,9 +85,9 @@ class AirflowDagFactory:
             self._manifest_file_path(config), config.get("use_task_group") or False
         )
         for starting_task in tasks.get_starting_tasks():
-            start >> starting_task.run_airflow_task
+            start >> starting_task.get_start_task()
         for ending_task in tasks.get_ending_tasks():
-            ending_task.test_airflow_task >> end
+            ending_task.get_end_task() >> end
 
     def _create_starting_task(self, config: dict) -> BaseOperator:
         if config.get("seed_task", True):

--- a/tests/manifest_ephemeral.json
+++ b/tests/manifest_ephemeral.json
@@ -2,7 +2,9 @@
   "nodes": {
     "model.dbt_test.model1": {
       "depends_on": {
-        "nodes": ["source.dbt_test.source1"]
+        "nodes": [
+          "source.dbt_test.source1"
+        ]
       },
       "config": {
         "materialized": "table"
@@ -95,6 +97,16 @@
         "nodes": [
           "model.dbt_test.model3",
           "model.dbt_test.model9"
+        ]
+      },
+      "config": {
+        "materialized": "ephemeral"
+      }
+    },
+    "model.dbt_test.model11": {
+      "depends_on": {
+        "nodes": [
+          "model.dbt_test.model10"
         ]
       },
       "config": {

--- a/tests/test_ephemeral_operator.py
+++ b/tests/test_ephemeral_operator.py
@@ -19,7 +19,7 @@ def test_ephemeral_dag_factory():
     dag = factory.create()
 
     # then
-    assert len(dag.tasks) == 15
+    assert len(dag.tasks) == 16
 
     task_group_names = [
         el
@@ -39,6 +39,7 @@ def test_ephemeral_dag_factory():
             "model8",
             "model9",
             "model10",
+            "model11",
         ]
     ]
     assert set(dag.task_ids) == set(
@@ -101,4 +102,12 @@ def test_ephemeral_tasks():
     assert (
         "model10__ephemeral"
         in tasks.get_task("model.dbt_test.model9").run_airflow_task.downstream_task_ids
+    )
+    assert (
+        "model11__ephemeral"
+        in tasks.get_task("model.dbt_test.model10").run_airflow_task.downstream_task_ids
+    )
+    assert (
+        "model10__ephemeral"
+        in tasks.get_task("model.dbt_test.model11").run_airflow_task.upstream_task_ids
     )


### PR DESCRIPTION
... to prevent ephemeral ending tasks from throwing.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates