### PR TITLE
Run indirect tests in freshly created nodes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ checks:
   argument-count:
     enabled: true
     config:
-      threshold: 4
+      threshold: 6
   complex-logic:
     enabled: true
     config:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage.xml
 *.iml
 
 docs/_build
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Run tests with more than one dependency in a different node.
+
 ## [0.19.0] - 2022-02-02
 
 ## [0.18.1] - 2022-01-18

--- a/dbt_airflow_factory/builder.py
+++ b/dbt_airflow_factory/builder.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, ContextManager, Dict, Tuple
+from typing import Any, ContextManager, Dict, KeysView, List, Tuple
 
 import airflow
 from airflow.models.baseoperator import BaseOperator
@@ -25,6 +25,32 @@ class DbtAirflowTasksBuilder:
     def __init__(self, operator_builder: DbtRunOperatorBuilder):
         self.operator_builder = operator_builder
 
+    class ModelTestsTuple:
+        def __init__(
+            self,
+            run_test_tasks: Dict[str, ModelExecutionTask],
+            multiple_dependency_test_tasks: Dict[Tuple[str, ...], ModelExecutionTask],
+        ) -> None:
+            self._run_test_tasks = run_test_tasks
+            self._multiple_dependency_test_tasks = multiple_dependency_test_tasks
+
+        @property
+        def result_tasks(self) -> Dict[str, ModelExecutionTask]:
+            result_tasks = dict(self._run_test_tasks)
+            for task_test_tuple, task_test in self._multiple_dependency_test_tasks.items():
+                result_tasks[
+                    DbtAirflowTasksBuilder._build_multiple_deps_test_name(task_test_tuple)
+                ] = task_test
+            return result_tasks
+
+        @property
+        def run_test_tasks_keys(self) -> KeysView[str]:
+            return self._run_test_tasks.keys()
+
+        @property
+        def multiple_dependency_test_tasks_keys(self) -> KeysView[Tuple[str, ...]]:
+            return self._multiple_dependency_test_tasks.keys()
+
     @staticmethod
     def _load_dbt_manifest(manifest_path: str) -> dict:
         with open(manifest_path, "r") as f:
@@ -40,6 +66,16 @@ class DbtAirflowTasksBuilder:
             model_name,
         )
 
+    def _make_dbt_multiple_deps_test_task(
+        self, test_names: List[str], dependencies: tuple
+    ) -> BaseOperator:
+        command = "test"
+        return self.operator_builder.create(
+            self._build_multiple_deps_test_name(dependencies),
+            command,
+            " ".join(test_names),
+        )
+
     def _make_dbt_run_task(self, model_name: str, is_in_task_group: bool) -> BaseOperator:
         command = "run"
         return self.operator_builder.create(
@@ -53,8 +89,20 @@ class DbtAirflowTasksBuilder:
         return command if is_in_task_group else f"{model_name}_{command}"
 
     @staticmethod
+    def _build_multiple_deps_test_name(dependencies: tuple) -> str:
+        return "_".join(map(lambda node_name: node_name.split(".")[-1], dependencies)) + "_test"
+
+    @staticmethod
+    def _is_task_type(node_name: str, task_type: str) -> bool:
+        return node_name.split(".")[0] == task_type
+
+    @staticmethod
     def _is_model_run_task(node_name: str) -> bool:
-        return node_name.split(".")[0] == "model"
+        return DbtAirflowTasksBuilder._is_task_type(node_name, "model")
+
+    @staticmethod
+    def _is_test_task(node_name: str) -> bool:
+        return DbtAirflowTasksBuilder._is_task_type(node_name, "test")
 
     @staticmethod
     def _is_ephemeral_task(node: dict) -> bool:
@@ -73,7 +121,15 @@ class DbtAirflowTasksBuilder:
         task_group_ctx = task_group or contextlib.nullcontext()
         return task_group, task_group_ctx
 
-    def _create_task_for_model(self, model_name: str, use_task_group: bool) -> ModelExecutionTask:
+    def _create_task_for_model(
+        self,
+        model_name: str,
+        is_ephemeral_task: bool,
+        use_task_group: bool,
+    ) -> ModelExecutionTask:
+        if is_ephemeral_task:
+            return ModelExecutionTask(EphemeralOperator(task_id=f"{model_name}__ephemeral"), None)
+
         (task_group, task_group_ctx) = self._create_task_group_for_model(model_name, use_task_group)
         is_in_task_group = task_group is not None
         with task_group_ctx:
@@ -83,42 +139,92 @@ class DbtAirflowTasksBuilder:
             run_task >> test_task
         return ModelExecutionTask(run_task, test_task, task_group)
 
+    def _create_tasks_for_each_multiple_deps_test(
+        self, manifest: dict
+    ) -> Dict[Tuple[str, ...], ModelExecutionTask]:
+        tests_with_more_deps: Dict[tuple, List[str]] = {}
+        for node in [v for k, v in manifest["nodes"].items() if self._is_test_task(k)]:
+            model_dependencies = list(filter(self._is_model_run_task, node["depends_on"]["nodes"]))
+            if len(model_dependencies) <= 1:
+                continue
+
+            model_dependencies.sort()
+            if tuple(model_dependencies) not in tests_with_more_deps:
+                tests_with_more_deps[tuple(model_dependencies)] = []
+            tests_with_more_deps[tuple(model_dependencies)].append(node["name"])
+
+        return {
+            depends_on_tuple: ModelExecutionTask(
+                self._make_dbt_multiple_deps_test_task(test_names, depends_on_tuple), None
+            )
+            for depends_on_tuple, test_names in tests_with_more_deps.items()
+        }
+
     def _create_tasks_for_each_model(
         self, manifest: dict, use_task_group: bool
     ) -> Dict[str, ModelExecutionTask]:
         tasks = {}
-        for node_name, node in manifest["nodes"].items():
-            if self._is_model_run_task(node_name):
-                logging.info("Creating tasks for: " + node_name)
-                model_name = node_name.split(".")[-1]
 
-                tasks[node_name] = (
-                    ModelExecutionTask(EphemeralOperator(task_id=f"{model_name}__ephemeral"), None)
-                    if self._is_ephemeral_task(node)
-                    else self._create_task_for_model(model_name, use_task_group)
-                )
+        for node_name, node in [
+            (str(k), v) for k, v in manifest["nodes"].items() if self._is_model_run_task(k)
+        ]:
+            logging.info("Creating tasks for: " + node_name)
+            tasks[node_name] = self._create_task_for_model(
+                node_name.split(".")[-1], self._is_ephemeral_task(node), use_task_group
+            )
+
         return tasks
 
+    @staticmethod
+    def _create_task_dependency(
+        upstream_node: str,
+        downstream_node: str,
+        result_tasks: Dict[str, ModelExecutionTask],
+        starting_tasks: List[str],
+        ending_tasks: List[str],
+    ) -> None:
+        # noinspection PyStatementEffect
+        (
+            result_tasks[upstream_node].get_end_task()
+            >> result_tasks[downstream_node].get_start_task()
+        )
+        if downstream_node in starting_tasks:
+            starting_tasks.remove(downstream_node)
+        if upstream_node in ending_tasks:
+            ending_tasks.remove(upstream_node)
+
     def _create_tasks_dependencies(
-        self, manifest: dict, tasks: Dict[str, ModelExecutionTask]
+        self,
+        manifest: dict,
+        model_tests_tuple: ModelTestsTuple,
     ) -> ModelExecutionTasks:
-        starting_tasks = list(tasks.keys())
-        ending_tasks = list(tasks.keys())
-        for node_name in tasks.keys():
+        result_tasks = model_tests_tuple.result_tasks
+        starting_tasks = list(result_tasks.keys())
+        ending_tasks = list(result_tasks.keys())
+
+        for node_name in model_tests_tuple.run_test_tasks_keys:
             for upstream_node in manifest["nodes"][node_name]["depends_on"]["nodes"]:
                 if self._is_model_run_task(upstream_node):
-                    # noinspection PyStatementEffect
-                    (tasks[upstream_node].get_end_task() >> tasks[node_name].get_start_task())
-                    if node_name in starting_tasks:
-                        starting_tasks.remove(node_name)
-                    if upstream_node in ending_tasks:
-                        ending_tasks.remove(upstream_node)
-        return ModelExecutionTasks(tasks, starting_tasks, ending_tasks)
+                    self._create_task_dependency(
+                        upstream_node, node_name, result_tasks, starting_tasks, ending_tasks
+                    )
+
+        for depends_on_tuple in model_tests_tuple.multiple_dependency_test_tasks_keys:
+            node_name = self._build_multiple_deps_test_name(depends_on_tuple)
+            for upstream_node in depends_on_tuple:
+                self._create_task_dependency(
+                    upstream_node, node_name, result_tasks, starting_tasks, ending_tasks
+                )
+
+        return ModelExecutionTasks(result_tasks, starting_tasks, ending_tasks)
 
     def _make_dbt_tasks(self, manifest_path: str, use_task_group: bool) -> ModelExecutionTasks:
         manifest = self._load_dbt_manifest(manifest_path)
-        tasks = self._create_tasks_for_each_model(manifest, use_task_group)
-        tasks_with_context = self._create_tasks_dependencies(manifest, tasks)
+        model_tests_tuple = self.ModelTestsTuple(
+            self._create_tasks_for_each_model(manifest, use_task_group),
+            self._create_tasks_for_each_multiple_deps_test(manifest),
+        )
+        tasks_with_context = self._create_tasks_dependencies(manifest, model_tests_tuple)
         logging.info(f"Created {str(tasks_with_context.length())} tasks groups")
         return tasks_with_context
 

--- a/dbt_airflow_factory/operator.py
+++ b/dbt_airflow_factory/operator.py
@@ -71,19 +71,17 @@ class KubernetesPodOperatorBuilder(DbtRunOperatorBuilder):
         return self._create(self._prepare_arguments(command, model), name)
 
     def _prepare_arguments(self, command: str, model: Optional[str]) -> List[str]:
-        args = (
-            f"set -e; "
-            f"dbt --no-write-json {command} "
-            f"--target {self.dbt_execution_env_parameters.target} "
-            f'--vars "{self.dbt_execution_env_parameters.vars}" '
-        )
+        args = [
+            "set -e;",
+            f"dbt --no-write-json {command}",
+            f"--target {self.dbt_execution_env_parameters.target}",
+            f'--vars "{self.dbt_execution_env_parameters.vars}"',
+            f"--project-dir {self.dbt_execution_env_parameters.project_dir_path}",
+            f"--profiles-dir {self.dbt_execution_env_parameters.profile_dir_path}",
+        ]
         if model:
-            args += f"--models {model} "
-        args += (
-            f"--project-dir {self.dbt_execution_env_parameters.project_dir_path} "
-            f"--profiles-dir {self.dbt_execution_env_parameters.profile_dir_path}"
-        )
-        return [args]
+            args += [f"--models {model}"]
+        return [" ".join(args)]
 
     def _create(self, args: Optional[List[str]], name: str) -> KubernetesPodOperator:
         return KubernetesPodOperator(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .utils import (
     builder_factory,
     manifest_file_with_models,
@@ -95,4 +97,218 @@ def test_more_complex_dependencies():
     assert (
         task_group_prefix_builder("model4", "run")
         in tasks.get_task("model.dbt_test.model3").test_airflow_task.downstream_task_ids
+    )
+
+
+def test_test_dependencies():
+    # given
+    manifest_path = manifest_file_with_models(
+        {
+            "model.dbt_test.model1": [],
+            "model.dbt_test.model2": ["model.dbt_test.model1"],
+            "model.dbt_test.model3": ["model.dbt_test.model2"],
+            "test.dbt_test.test1": ["model.dbt_test.model1"],
+            "test.dbt_test.test2": ["model.dbt_test.model1", "model.dbt_test.model2"],
+        }
+    )
+
+    # when
+    with test_dag():
+        tasks = builder_factory().create().parse_manifest_into_tasks(manifest_path)
+
+    # then
+    assert tasks.length() == 4
+    assert (
+        task_group_prefix_builder("model1", "test")
+        in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model3", "run")
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+
+    assert (
+        "model1_model2_test"
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model1", "test")
+        in tasks.get_task("model1_model2_test").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model1_model2_test"
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model1_model2_test").run_airflow_task.upstream_task_ids
+    )
+
+
+def test_complex_test_dependencies():
+    # given
+    manifest_path = manifest_file_with_models(
+        {
+            "model.dbt_test.model1": [],
+            "model.dbt_test.model2": ["model.dbt_test.model1"],
+            "model.dbt_test.model3": ["model.dbt_test.model2"],
+            "model.dbt_test.model4": ["model.dbt_test.model1", "model.dbt_test.model2"],
+            "model.dbt_test.model5": [],
+            "model.dbt_test.model6": [],
+            "model.dbt_test.model7": ["model.dbt_test.model6", "model.dbt_test.model5"],
+            "test.dbt_test.test1": ["model.dbt_test.model6", "model.dbt_test.model5"],
+            "test.dbt_test.test2": ["model.dbt_test.model7", "model.dbt_test.model2"],
+            "test.dbt_test.test3": ["model.dbt_test.model2", "model.dbt_test.model3"],
+            "test.dbt_test.test4": ["model.dbt_test.model3", "model.dbt_test.model2"],
+            "test.dbt_test.test5": ["model.dbt_test.model3", "model.dbt_test.model2"],
+        }
+    )
+
+    # when
+    with test_dag():
+        tasks = builder_factory().create().parse_manifest_into_tasks(manifest_path)
+
+    # then
+    assert tasks.length() == 10
+    assert (
+        task_group_prefix_builder("model1", "test")
+        in tasks.get_task("model.dbt_test.model2").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model.dbt_test.model3").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model3", "run")
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model1", "test")
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model.dbt_test.model4").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model4", "run")
+        in tasks.get_task("model.dbt_test.model1").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model4", "run")
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model5", "test")
+        in tasks.get_task("model.dbt_test.model7").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model7", "run")
+        in tasks.get_task("model.dbt_test.model5").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model6", "test")
+        in tasks.get_task("model.dbt_test.model7").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model7", "run")
+        in tasks.get_task("model.dbt_test.model6").test_airflow_task.downstream_task_ids
+    )
+
+    def extract_model_arguments(args: str) -> List[str]:
+        return list(filter(lambda s: not s.startswith("-"), args.split("--models ")[1].split()))
+
+    assert (
+        "model2_model3_test"
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model2_model3_test").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model2_model3_test"
+        in tasks.get_task("model.dbt_test.model3").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model3", "test")
+        in tasks.get_task("model2_model3_test").run_airflow_task.upstream_task_ids
+    )
+    assert all(
+        test_name
+        in extract_model_arguments(
+            tasks.get_task("model2_model3_test").run_airflow_task.arguments[0]
+        )
+        for test_name in ["test3", "test4", "test5"]
+    )
+    assert all(
+        test_name
+        not in extract_model_arguments(
+            tasks.get_task("model2_model3_test").run_airflow_task.arguments[0]
+        )
+        for test_name in ["test1", "test2"]
+    )
+    assert (
+        "model2_model7_test"
+        in tasks.get_task("model.dbt_test.model2").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model2", "test")
+        in tasks.get_task("model2_model7_test").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model2_model7_test"
+        in tasks.get_task("model.dbt_test.model7").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model7", "test")
+        in tasks.get_task("model2_model7_test").run_airflow_task.upstream_task_ids
+    )
+    assert "test2" in extract_model_arguments(
+        tasks.get_task("model2_model7_test").run_airflow_task.arguments[0]
+    )
+    assert all(
+        test_name
+        not in extract_model_arguments(
+            tasks.get_task("model2_model7_test").run_airflow_task.arguments[0]
+        )
+        for test_name in ["test1", "test3", "test4", "test5"]
+    )
+    assert (
+        "model5_model6_test"
+        in tasks.get_task("model.dbt_test.model5").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model5", "test")
+        in tasks.get_task("model5_model6_test").run_airflow_task.upstream_task_ids
+    )
+    assert (
+        "model5_model6_test"
+        in tasks.get_task("model.dbt_test.model6").test_airflow_task.downstream_task_ids
+    )
+    assert (
+        task_group_prefix_builder("model6", "test")
+        in tasks.get_task("model5_model6_test").run_airflow_task.upstream_task_ids
+    )
+    assert "test1" in extract_model_arguments(
+        tasks.get_task("model5_model6_test").run_airflow_task.arguments[0]
+    )
+    assert all(
+        test_name
+        not in extract_model_arguments(
+            tasks.get_task("model5_model6_test").run_airflow_task.arguments[0]
+        )
+        for test_name in ["test2", "test3", "test4", "test5"]
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,7 @@ def manifest_file_with_models(nodes_with_dependencies):
         content_nodes[node_name] = {
             "depends_on": {"nodes": nodes_with_dependencies[node_name]},
             "config": {"materialized": "view"},
+            "name": node_name.split(".")[-1],
         }
     content = {"nodes": content_nodes}
     with tempfile.NamedTemporaryFile(delete=False) as tmp:


### PR DESCRIPTION
In dbt `0.20` and `0.21`, dbt _by default_ does not run so-called "indirect" tests – tests which have multiple dependencies and at least one of them is not listed in `--models`. The exact opposite happens in dbt `1.0.0`: dbt _by default_ runs all the tests for a specific model, even the indirect ones. It may become a problem, if a specific test has dependency which has not been processed yet.

This PR does two things. First of all, it stops `dbt >= 1.0.0` from running indirect tests by attaching a special flag to dbt. Futhermore, it introduces new Kubernetes nodes that run indirect tests whenever all of their dependencies are run. Unfortunately, for now those tests are not added as dependencies of their parents children, as it is quite a bigger task that should be addressed in the future.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates