### PR TITLE
Remove ephemeral tasks from DAG

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ known_first_party = dbt_airflow_factory
 default_section = THIRDPARTY
 
 [settings]
-known_third_party = airflow,jinja2,pytimeparse,setuptools,yaml
+known_third_party = airflow,jinja2,networkx,pytimeparse,setuptools,yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Ephemeral nodes can be hidden from DAG by setting `show_ephemeral_models: False` in project's `airflow.yml`.
+
 ## [0.21.0] - 2022-02-11
 
 This version brings compatibility with `dbt 1.0`.

--- a/dbt_airflow_factory/airflow_dag_factory.py
+++ b/dbt_airflow_factory/airflow_dag_factory.py
@@ -86,8 +86,8 @@ class AirflowDagFactory:
         end = DummyOperator(task_id="end")
         tasks = self._builder.parse_manifest_into_tasks(
             self._manifest_file_path(config),
-            config.get("use_task_group") or False,
-            config.get("show_ephemeral_models") or True,
+            config.get("use_task_group", False),
+            config.get("show_ephemeral_models", True),
         )
         for starting_task in tasks.get_starting_tasks():
             start >> starting_task.get_start_task()

--- a/dbt_airflow_factory/airflow_dag_factory.py
+++ b/dbt_airflow_factory/airflow_dag_factory.py
@@ -85,7 +85,9 @@ class AirflowDagFactory:
         start = self._create_starting_task(config)
         end = DummyOperator(task_id="end")
         tasks = self._builder.parse_manifest_into_tasks(
-            self._manifest_file_path(config), config.get("use_task_group") or False
+            self._manifest_file_path(config),
+            config.get("use_task_group") or False,
+            config.get("show_ephemeral_models") or True,
         )
         for starting_task in tasks.get_starting_tasks():
             start >> starting_task.get_start_task()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-click>=3.0,<3.1
 myst-parser>=0.16, <0.17
 docutils<0.17
 apache-airflow[kubernetes]>=2.2.0,<3.0.0
+networkx==2.6.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     README = f.read()
 
 # Runtime Requirements.
-INSTALL_REQUIRES = ["pytimeparse==1.1.8"]
+INSTALL_REQUIRES = ["pytimeparse==1.1.8", "networkx==2.6.3"]
 
 # Dev Requirements
 EXTRA_REQUIRE = {

--- a/tests/config/base/airflow.yml
+++ b/tests/config/base/airflow.yml
@@ -20,3 +20,4 @@ seed_task: True
 manifest_file_name: ../tests/manifest.json
 use_task_group: True
 dags_path: "gs://example-bucket/dags/experimental-sandbox"
+show_ephemeral_models: True

--- a/tests/config/no_ephemeral_operator/airflow.yml
+++ b/tests/config/no_ephemeral_operator/airflow.yml
@@ -1,0 +1,2 @@
+manifest_file_name: ../tests/manifest_ephemeral.json
+show_ephemeral_models: False

--- a/tests/manifest_ephemeral.json
+++ b/tests/manifest_ephemeral.json
@@ -1,6 +1,7 @@
 {
   "nodes": {
     "model.dbt_test.model1": {
+      "name": "model1",
       "depends_on": {
         "nodes": [
           "source.dbt_test.source1"
@@ -11,6 +12,7 @@
       }
     },
     "model.dbt_test.model2": {
+      "name": "model2",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model1"
@@ -21,6 +23,7 @@
       }
     },
     "model.dbt_test.model3": {
+      "name": "model3",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model2",
@@ -32,6 +35,7 @@
       }
     },
     "model.dbt_test.model4": {
+      "name": "model4",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model10"
@@ -42,6 +46,7 @@
       }
     },
     "model.dbt_test.model5": {
+      "name": "model5",
       "depends_on": {
         "nodes": [
           "source.dbt_test.source2"
@@ -52,6 +57,7 @@
       }
     },
     "model.dbt_test.model6": {
+      "name": "model6",
       "depends_on": {
         "nodes": [
           "source.dbt_test.source3"
@@ -62,6 +68,7 @@
       }
     },
     "model.dbt_test.model7": {
+      "name": "model7",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model6"
@@ -72,6 +79,7 @@
       }
     },
     "model.dbt_test.model8": {
+      "name": "model8",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model6"
@@ -82,6 +90,7 @@
       }
     },
     "model.dbt_test.model9": {
+      "name": "model9",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model7",
@@ -93,6 +102,7 @@
       }
     },
     "model.dbt_test.model10": {
+      "name": "model10",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model3",
@@ -104,6 +114,7 @@
       }
     },
     "model.dbt_test.model11": {
+      "name": "model11",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model10"

--- a/tests/manifest_task_group_tests.json
+++ b/tests/manifest_task_group_tests.json
@@ -1,6 +1,7 @@
 {
   "nodes": {
     "model.dbt_test.model1": {
+      "name": "model1",
       "depends_on": {
         "nodes": []
       },
@@ -9,6 +10,7 @@
       }
     },
     "model.dbt_test.model2": {
+      "name": "model2",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model1"
@@ -19,6 +21,7 @@
       }
     },
     "model.dbt_test.model3": {
+      "name": "model3",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model1"
@@ -29,6 +32,7 @@
       }
     },
     "model.dbt_test.model4": {
+      "name": "model4",
       "depends_on": {
         "nodes": [
           "model.dbt_test.model2",


### PR DESCRIPTION
Ephemeral tasks can be hidden in the Airflow DAG, if `airflow.yml`'s flag `show_ephemeral_models` is set to `False`.

This PR also reworks graph generation a bit, relying on `networkx` instead of plain dictionaries.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates