### PR TITLE
Do not use deprecated Kubernetes settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Use `node_selector` and `container_resources` parameters in `KubernetesPodOperator` if Airflow is 2.3+.
+
 ## [0.30.0] - 2023-02-08
 
 -   Add in_cluster, cluster_context params

--- a/dbt_airflow_factory/airflow_dag_factory.py
+++ b/dbt_airflow_factory/airflow_dag_factory.py
@@ -2,13 +2,13 @@
 
 import os
 
-import airflow
 from airflow import DAG
 from airflow.models import BaseOperator
 
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 from dbt_airflow_factory.ingestion import IngestionEngine, IngestionFactory
 
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.operators.dummy_operator import DummyOperator
 else:
     from airflow.operators.dummy import DummyOperator

--- a/dbt_airflow_factory/constants.py
+++ b/dbt_airflow_factory/constants.py
@@ -1,0 +1,6 @@
+import airflow
+
+IS_FIRST_AIRFLOW_VERSION = airflow.__version__.startswith("1.")
+IS_AIRFLOW_NEWER_THAN_2_4 = not IS_FIRST_AIRFLOW_VERSION and (
+    not airflow.__version__.startswith("2.") or int(airflow.__version__.split(".")[1]) > 4
+)

--- a/dbt_airflow_factory/ecs/ecs_operator.py
+++ b/dbt_airflow_factory/ecs/ecs_operator.py
@@ -10,7 +10,6 @@ from dbt_airflow_factory.operator import DbtRunOperatorBuilder
 
 
 class EcsPodOperatorBuilder(DbtRunOperatorBuilder):
-
     dbt_execution_env_parameters: DbtExecutionEnvironmentParameters
     """POD representing DBT operator config file."""
     ecs_execution_parameters: EcsExecutionParameters

--- a/dbt_airflow_factory/k8s/k8s_operator.py
+++ b/dbt_airflow_factory/k8s/k8s_operator.py
@@ -3,13 +3,12 @@
 import inspect
 from typing import List, Optional
 
-import airflow
-
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 from dbt_airflow_factory.dbt_parameters import DbtExecutionEnvironmentParameters
 from dbt_airflow_factory.k8s.k8s_parameters import KubernetesExecutionParameters
 from dbt_airflow_factory.operator import DbtRunOperatorBuilder
 
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 else:
     from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
@@ -75,7 +74,7 @@ class KubernetesPodOperatorBuilder(DbtRunOperatorBuilder):
     def _create(self, args: Optional[List[str]], name: str) -> KubernetesPodOperator:
         airflow_compatibility_dict = {
             "node_selectors"
-            if airflow.__version__.startswith("1.")
+            if IS_FIRST_AIRFLOW_VERSION
             else "node_selector": self.kubernetes_execution_parameters.node_selectors,
             # Since Airflow 2.3, https://github.com/apache/airflow/blob/12c3c39d1a816c99c626fe4c650e88cf7b1cc1bc/airflow/providers/cncf/kubernetes/CHANGELOG.rst#500  # noqa: E501
             "container_resources"

--- a/dbt_airflow_factory/k8s/k8s_parameters.py
+++ b/dbt_airflow_factory/k8s/k8s_parameters.py
@@ -2,9 +2,9 @@
 
 from typing import Any, Dict, List, Optional
 
-import airflow
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.contrib.kubernetes.secret import Secret
 else:
     from airflow.kubernetes.secret import Secret
@@ -102,7 +102,7 @@ class KubernetesExecutionParameters:
 
         :return: Dictionary containing resources requests and limits.
         """
-        if airflow.__version__.startswith("1."):
+        if IS_FIRST_AIRFLOW_VERSION:
             return {
                 "limit_memory": self._limit["memory"] if self._limit else None,
                 "limit_cpu": self._limit["cpu"] if self._limit else None,
@@ -130,7 +130,7 @@ class KubernetesExecutionParameters:
         if self._env_vars is None:
             return None
 
-        if airflow.__version__.startswith("1."):
+        if IS_FIRST_AIRFLOW_VERSION:
             return self._env_vars
         else:
             from kubernetes.client import models as k8s

--- a/dbt_airflow_factory/notifications/handler.py
+++ b/dbt_airflow_factory/notifications/handler.py
@@ -1,13 +1,20 @@
 from collections.abc import Callable
 from typing import Any
 
-import airflow
+from dbt_airflow_factory.constants import (
+    IS_AIRFLOW_NEWER_THAN_2_4,
+    IS_FIRST_AIRFLOW_VERSION,
+)
 
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 else:
     from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
-from airflow.hooks.base_hook import BaseHook
+
+if IS_AIRFLOW_NEWER_THAN_2_4:
+    from airflow.hooks.base import BaseHook
+else:
+    from airflow.hooks.base_hook import BaseHook
 
 
 class NotificationHandlersFactory:

--- a/dbt_airflow_factory/operator.py
+++ b/dbt_airflow_factory/operator.py
@@ -3,9 +3,9 @@
 import abc
 from typing import List, Optional
 
-import airflow
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.operators.dummy_operator import DummyOperator
 else:
     from airflow.operators.dummy import DummyOperator

--- a/dbt_airflow_factory/tasks_builder/builder.py
+++ b/dbt_airflow_factory/tasks_builder/builder.py
@@ -167,7 +167,6 @@ class DbtAirflowTasksBuilder:
         return tasks_with_context
 
     def _create_tasks_graph(self, manifest: dict) -> DbtAirflowGraph:
-
         dbt_airflow_graph = DbtAirflowGraph(self.gateway_config)
         dbt_airflow_graph.add_execution_tasks(manifest)
         if self.airflow_config.enable_dags_dependencies:

--- a/dbt_airflow_factory/tasks_builder/builder.py
+++ b/dbt_airflow_factory/tasks_builder/builder.py
@@ -3,15 +3,15 @@ import json
 import logging
 from typing import Any, ContextManager, Dict, Tuple
 
-import airflow
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.sensors.external_task_sensor import ExternalTaskSensor
 
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 from dbt_airflow_factory.tasks_builder.node_type import NodeType
 from dbt_airflow_factory.tasks_builder.parameters import TasksBuildingParameters
 
-if not airflow.__version__.startswith("1."):
+if not IS_FIRST_AIRFLOW_VERSION:
     from airflow.utils.task_group import TaskGroup
 
 from dbt_airflow_factory.operator import DbtRunOperatorBuilder, EphemeralOperator
@@ -102,9 +102,10 @@ class DbtAirflowTasksBuilder:
     ) -> Tuple[Any, ContextManager]:
         import contextlib
 
-        is_first_version = airflow.__version__.startswith("1.")
         task_group = (
-            None if (is_first_version or not use_task_group) else TaskGroup(group_id=model_name)
+            None
+            if (IS_FIRST_AIRFLOW_VERSION or not use_task_group)
+            else TaskGroup(group_id=model_name)
         )
         task_group_ctx = task_group or contextlib.nullcontext()
         return task_group, task_group_ctx

--- a/dbt_airflow_factory/tasks_builder/graph.py
+++ b/dbt_airflow_factory/tasks_builder/graph.py
@@ -266,7 +266,6 @@ class DbtAirflowGraph:
 
 
 def _get_node_properties(node_name: str, manifest: Dict[str, Any]) -> NodeProperties:
-
     resources = manifest["sources"] if is_source_sensor_task(node_name) else manifest["nodes"]
     return NodeProperties(
         node_name=node_name,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ EXTRA_REQUIRE = {
         "tox==3.21.1",
         "pre-commit==2.9.3",
         "pandas==1.2.5",
-        "apache-airflow[kubernetes,slack]==2.2.0",
+        "apache-airflow[kubernetes,slack]==2.5.2",
         "apache-airflow-providers-airbyte==3.1.0",
     ],
     "docs": [

--- a/tests/test_config_propagation.py
+++ b/tests/test_config_propagation.py
@@ -1,4 +1,5 @@
 from .utils import (
+    IS_AIRFLOW_NEWER_THAN_2_4,
     IS_FIRST_AIRFLOW_VERSION,
     builder_factory,
     manifest_file_with_models,
@@ -34,8 +35,12 @@ def test_configuration():
         assert run_task.tolerations[0].operator == "Equal"
         assert run_task.tolerations[0].value == "data-processing"
         assert run_task.tolerations[0].effect == "NoSchedule"
-        assert run_task.k8s_resources.limits == {"memory": "2048M", "cpu": "2"}
-        assert run_task.k8s_resources.requests == {"memory": "1024M", "cpu": "1"}
+        if IS_AIRFLOW_NEWER_THAN_2_4:
+            assert run_task.container_resources.limits == {"memory": "2048M", "cpu": "2"}
+            assert run_task.container_resources.requests == {"memory": "1024M", "cpu": "1"}
+        else:
+            assert run_task.k8s_resources.limits == {"memory": "2048M", "cpu": "2"}
+            assert run_task.k8s_resources.requests == {"memory": "1024M", "cpu": "1"}
 
     assert run_task.startup_timeout_seconds == 120
 

--- a/tests/test_config_propagation.py
+++ b/tests/test_config_propagation.py
@@ -1,10 +1,9 @@
-from .utils import (
+from dbt_airflow_factory.constants import (
     IS_AIRFLOW_NEWER_THAN_2_4,
     IS_FIRST_AIRFLOW_VERSION,
-    builder_factory,
-    manifest_file_with_models,
-    test_dag,
 )
+
+from .utils import builder_factory, manifest_file_with_models, test_dag
 
 
 def test_configuration():

--- a/tests/test_dag_factory.py
+++ b/tests/test_dag_factory.py
@@ -5,8 +5,7 @@ from typing import Set
 import pytest
 
 from dbt_airflow_factory.airflow_dag_factory import AirflowDagFactory
-
-from .utils import IS_FIRST_AIRFLOW_VERSION
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
 
 def test_dag_factory():

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import airflow
 
+from tests.utils import IS_AIRFLOW_NEWER_THAN_2_4, IS_FIRST_AIRFLOW_VERSION
+
 if airflow.__version__.startswith("1."):
     from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 else:
@@ -24,14 +26,13 @@ def test_notification_callback_creation():
 
 
 @patch(
-    "airflow.hooks.base_hook.BaseHook.get_connection"
-    if airflow.__version__.startswith("1.")
-    or (airflow.__version__.startswith("2.") and int(airflow.__version__.split(".")[1]) < 4)
-    else "airflow.hooks.base.BaseHook.get_connection"
+    "airflow.hooks.base.BaseHook.get_connection"
+    if IS_AIRFLOW_NEWER_THAN_2_4
+    else "airflow.hooks.base_hook.BaseHook.get_connection"
 )
 @patch(
     "airflow.contrib.operators.slack_webhook_operator.SlackWebhookOperator.__new__"
-    if airflow.__version__.startswith("1.")
+    if IS_FIRST_AIRFLOW_VERSION
     else "airflow.providers.slack.operators.slack_webhook.SlackWebhookOperator.__new__"
 )
 def test_notification_send(mock_operator_init, mock_get_connection):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,11 +1,12 @@
 from os import path
 from unittest.mock import MagicMock, patch
 
-import airflow
+from dbt_airflow_factory.constants import (
+    IS_AIRFLOW_NEWER_THAN_2_4,
+    IS_FIRST_AIRFLOW_VERSION,
+)
 
-from tests.utils import IS_AIRFLOW_NEWER_THAN_2_4, IS_FIRST_AIRFLOW_VERSION
-
-if airflow.__version__.startswith("1."):
+if IS_FIRST_AIRFLOW_VERSION:
     from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 else:
     from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -23,8 +23,17 @@ def test_notification_callback_creation():
     assert dag.default_args["on_failure_callback"]
 
 
-@patch("airflow.hooks.base_hook.BaseHook.get_connection")
-@patch("airflow.contrib.operators.slack_webhook_operator.SlackWebhookOperator.__new__")
+@patch(
+    "airflow.hooks.base_hook.BaseHook.get_connection"
+    if airflow.__version__.startswith("1.")
+    or (airflow.__version__.startswith("2.") and int(airflow.__version__.split(".")[1]) < 4)
+    else "airflow.hooks.base.BaseHook.get_connection"
+)
+@patch(
+    "airflow.contrib.operators.slack_webhook_operator.SlackWebhookOperator.__new__"
+    if airflow.__version__.startswith("1.")
+    else "airflow.providers.slack.operators.slack_webhook.SlackWebhookOperator.__new__"
+)
 def test_notification_send(mock_operator_init, mock_get_connection):
     # given
     notifications_config = AirflowDagFactory(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,9 +1,9 @@
 from os import path
 
 from dbt_airflow_factory.builder_factory import DbtAirflowTasksBuilderFactory
+from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
 from .utils import (
-    IS_FIRST_AIRFLOW_VERSION,
     builder_factory,
     manifest_file_with_models,
     task_group_prefix_builder,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from datetime import datetime
 
-import airflow
 from airflow import DAG
 
 from dbt_airflow_factory.builder_factory import DbtAirflowTasksBuilderFactory
@@ -40,13 +39,9 @@ def test_dag():
     return DAG("test", default_args={"start_date": datetime(2021, 10, 13)})
 
 
-IS_FIRST_AIRFLOW_VERSION = airflow.__version__.startswith("1.")
-IS_AIRFLOW_NEWER_THAN_2_4 = not IS_FIRST_AIRFLOW_VERSION and (
-    not airflow.__version__.startswith("2.") or int(airflow.__version__.split(".")[1]) > 4
-)
-
-
 def task_group_prefix_builder(task_model_id: str, task_command: str) -> str:
+    from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
+
     return (
         f"{task_model_id}_{task_command}"
         if IS_FIRST_AIRFLOW_VERSION

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,6 +41,9 @@ def test_dag():
 
 
 IS_FIRST_AIRFLOW_VERSION = airflow.__version__.startswith("1.")
+IS_AIRFLOW_NEWER_THAN_2_4 = not IS_FIRST_AIRFLOW_VERSION and (
+    not airflow.__version__.startswith("2.") or int(airflow.__version__.split(".")[1]) > 4
+)
 
 
 def task_group_prefix_builder(task_model_id: str, task_command: str) -> str:


### PR DESCRIPTION
Since Airflow 2.3, KubernetesPodOperator should not use "node_selectors" and "resources" parameters, but "node_selector" and "container_resources" respectively instead.

It is partially based on #80 by @maver1ck. And should close #79.

---
Keep in mind:
- [ ] Documentation updates
- [X] [Changelog](CHANGELOG.md) updates