### PR TITLE
fix: replace default param with None

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,18 +10,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace `config_file` default value from `"~/.kube/config"` to `None` in `KubernetesPodOperator` [#90](https://github.com/getindata/dbt-airflow-factory/issues/90)
+
 ## [0.31.0] - 2023-03-27
 
 ### Fixed

--- a/dbt_airflow_factory/k8s/k8s_parameters.py
+++ b/dbt_airflow_factory/k8s/k8s_parameters.py
@@ -1,6 +1,6 @@
 """POD representing Kubernetes operator config file."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
@@ -39,6 +39,9 @@ class KubernetesExecutionParameters:
     :param is_delete_operator_pod: What to do when the pod reaches its final
         state, or the execution is interrupted. If True: delete the pod.
     :type is_delete_operator_pod: bool
+    :param config_file: The path to the Kubernetes config file. (templated)
+        If not specified, default value is ``~/.kube/config``
+    :type config_file: str
     :param execution_script: Script that will be executed inside pod.
     :type execution_script: str
     :param in_cluster: Run kubernetes client with in_cluster configuration.
@@ -62,7 +65,7 @@ class KubernetesExecutionParameters:
         envs: Optional[Dict[str, str]] = None,
         secrets: Optional[List[Secret]] = None,
         is_delete_operator_pod: bool = True,
-        config_file: Union[str, None] = None,
+        config_file: Optional[str] = None,
         execution_script: str = "dbt --no-write-json",
         in_cluster: Optional[bool] = None,
         cluster_context: Optional[str] = None,

--- a/dbt_airflow_factory/k8s/k8s_parameters.py
+++ b/dbt_airflow_factory/k8s/k8s_parameters.py
@@ -1,6 +1,6 @@
 """POD representing Kubernetes operator config file."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from dbt_airflow_factory.constants import IS_FIRST_AIRFLOW_VERSION
 
@@ -62,7 +62,7 @@ class KubernetesExecutionParameters:
         envs: Optional[Dict[str, str]] = None,
         secrets: Optional[List[Secret]] = None,
         is_delete_operator_pod: bool = True,
-        config_file: str = "~/.kube/config",
+        config_file: Union[str, None] = None,
         execution_script: str = "dbt --no-write-json",
         in_cluster: Optional[bool] = None,
         cluster_context: Optional[str] = None,

--- a/dbt_airflow_factory/k8s/k8s_parameters.py
+++ b/dbt_airflow_factory/k8s/k8s_parameters.py
@@ -41,7 +41,7 @@ class KubernetesExecutionParameters:
     :type is_delete_operator_pod: bool
     :param config_file: The path to the Kubernetes config file. (templated)
         If not specified, default value is ``~/.kube/config``
-    :type config_file: str
+    :type config_file: Optional[str]
     :param execution_script: Script that will be executed inside pod.
     :type execution_script: str
     :param in_cluster: Run kubernetes client with in_cluster configuration.


### PR DESCRIPTION
Resolves #90 

changes:
- due to urlib3 release `.readthedocs.yaml` config file was added for reference [issue](https://github.com/readthedocs/readthedocs.org/issues/10290)
- replaced default value  `config_file: str = "~/.kube/config"` to `config_file: Optional[str] = None`
---
Keep in mind:
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates