### PR TITLE
Adding kwargs to BashExecutionParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Add `kwargs` to `BashExecutionParameters` [#90](https://github.com/getindata/dbt-airflow-factory/issues/90)
+
 ## [0.32.0] - 2023-07-04
 
 ## [0.31.1] - 2023-05-12

--- a/dbt_airflow_factory/bash/bash_parameters.py
+++ b/dbt_airflow_factory/bash/bash_parameters.py
@@ -1,5 +1,7 @@
 """POD representing Bash operator config file."""
 
+from typing import Any
+
 
 class BashExecutionParameters:
     """POD representing Bash operator config file.
@@ -7,8 +9,5 @@ class BashExecutionParameters:
     :type execution_script: str
     """
 
-    def __init__(
-        self,
-        execution_script: str = "dbt --no-write-json",
-    ) -> None:
+    def __init__(self, execution_script: str = "dbt --no-write-json", **kwargs: Any) -> None:
         self.execution_script = execution_script


### PR DESCRIPTION
`<description>`

Resolves #95 .

`BashExecutionParameters` will now accept kwargs similar to other classes such as `EcsExecutionParameters` and `KubernetesExecutionParameters`.

---
Keep in mind:
- [x] Documentation updates
- [x] [Changelog](CHANGELOG.md) updates