### PR TITLE
Ensure 'envs' key exists in config before updating

### DIFF
--- a/dbt_airflow_factory/k8s/k8s_parameters_loader.py
+++ b/dbt_airflow_factory/k8s/k8s_parameters_loader.py
@@ -24,6 +24,9 @@ class KubernetesExecutionParametersLoader:
 
     @staticmethod
     def _update_config_if_datahub_exits(config: dict, datahub_config: dict) -> dict:
+        if "envs" not in config:
+            config["envs"] = {}
+
         if datahub_config:
             config["envs"].update({"DATAHUB_GMS_URL": datahub_config["sink"]["config"]["server"]})
         return config


### PR DESCRIPTION
### Description

This PR updates the `k8s_parameters_loader.py` script to ensure that the `envs` key is present in the configuration dictionary before attempting to update it. Previously, the absence of the `envs` key would lead to a KeyError, disrupting the configuration process. The modification includes a conditional check that initializes `envs` as an empty dictionary if it is not already present, thus preventing any errors when updating the configuration with the DATAHUB_GMS_URL.